### PR TITLE
Fix segmentation fault if used with the options -1 -C

### DIFF
--- a/iptstate.cc
+++ b/iptstate.cc
@@ -2183,7 +2183,6 @@ int main(int argc, char *argv[])
   // Command Line Arguments
   while ((tmpint = getopt_long(argc, argv, "Cd:D:hlmcoLfpR:r1b:s:S:tv",
                                long_options, &option_index)) != EOF) {
-    printf("loop: %d\n", tmpint);
     switch (tmpint) {
     case 0:
       /* Apparently this test is needed?! Seems lame! */

--- a/iptstate.cc
+++ b/iptstate.cc
@@ -2407,7 +2407,10 @@ int main(int argc, char *argv[])
       prompt = "Counters requested, but not enabled in the";
       prompt += " kernel!";
       flags.counters = 0;
-      c_warn(mainwin, prompt, flags);
+      if (flags.single)
+	  cerr << prompt << endl;
+      else
+	  c_warn(mainwin, prompt, flags);
     }
 
     // Sort our table

--- a/iptstate.cc
+++ b/iptstate.cc
@@ -743,6 +743,10 @@ void c_warn(WINDOW *win, const string &warning, const flags_t &flags)
    */
   
   int x, y;
+  if (flags.single) {
+    cerr << warning << endl;
+    return;
+  }
   getmaxyx(stdscr, y, x);
   WINDOW *warn = subpad(win, 1, x, 0, 0);
   if (!flags.nocolor)

--- a/iptstate.cc
+++ b/iptstate.cc
@@ -743,10 +743,6 @@ void c_warn(WINDOW *win, const string &warning, const flags_t &flags)
    */
   
   int x, y;
-  if (flags.single) {
-    cerr << warning << endl;
-    return;
-  }
   getmaxyx(stdscr, y, x);
   WINDOW *warn = subpad(win, 1, x, 0, 0);
   if (!flags.nocolor)


### PR DESCRIPTION
Curses is not used with the "-1" single option, but c_warn is used if
counters are not enabled in the kernel and "-C" option is given.

Fixes: RHBZ#599181