### PR TITLE
Fix segmentation fault if used with the options -1 -C

### DIFF
--- a/iptstate.cc
+++ b/iptstate.cc
@@ -2407,7 +2407,10 @@ int main(int argc, char *argv[])
       prompt = "Counters requested, but not enabled in the";
       prompt += " kernel!";
       flags.counters = 0;
-      c_warn(mainwin, prompt, flags);
+      if (flags.single)
+	  cerr << prompt << endl;
+      else
+	  c_warn(mainwin, prompt, flags);
     }
 
     // Sort our table


### PR DESCRIPTION
Curses is not used with the "-1" single option, but c_warn is used if
counters are not enabled in the kernel and "-C" option is given.

Fixes: RHBZ#599181
