### PR TITLE
Fix segfault when determining terminal width

### DIFF
--- a/iptstate.cc
+++ b/iptstate.cc
@@ -587,17 +587,14 @@ screensize_t get_size(const bool &single)
   int maxx = 0, maxy = 0;
   if (!single) {          
     getmaxyx(stdscr, maxy, maxx);
-  } else {                             
-    maxx = 72;
-
+  } else {
     // https://stackoverflow.com/questions/1022957/
     struct winsize w;
     ioctl(0, TIOCGWINSZ, &w);
     maxx = w.ws_col;
 
     if (getenv("COLS"))
-      maxx=atoi(getenv("COLS"));
-
+      maxx = atoi(getenv("COLS"));
   }
 
   screensize_t a;

--- a/iptstate.cc
+++ b/iptstate.cc
@@ -1586,7 +1586,10 @@ void determine_format(WINDOW *mainwin, max_t &max, screensize_t &ssize,
          */
   if (ssize.x < 85 && flags.counters && !flags.lookup) {
     string prompt = "Window too narrow for counters! Disabling.";
-    c_warn(mainwin, prompt, flags);
+    if (flags.single)
+      cerr << prompt << endl;
+    else
+      c_warn(mainwin, prompt, flags);
     flags.counters = false;
   }
 

--- a/iptstate.cc
+++ b/iptstate.cc
@@ -62,6 +62,7 @@ extern "C" {
 #include <netdb.h>
 #include <ncurses.h>
 #include <unistd.h>
+#include <sys/ioctl.h>
 using namespace std;
 
 #define VERSION "2.2.6"
@@ -588,8 +589,15 @@ screensize_t get_size(const bool &single)
     getmaxyx(stdscr, maxy, maxx);
   } else {                             
     maxx = 72;
+
+    // https://stackoverflow.com/questions/1022957/
+    struct winsize w;
+    ioctl(0, TIOCGWINSZ, &w);
+    maxx = w.ws_col;
+
     if (getenv("COLS"))
       maxx=atoi(getenv("COLS"));
+
   }
 
   screensize_t a;


### PR DESCRIPTION
When `$COLS` env. variable is not set, the terminal size is hardcoded at 72. When enabling `--counters` this segfaults when displaying error because terminal width is < 85 chars and ncurses is not loaded (similar issue as #10).

Second patch determines the terminal width automatically but maybe it's simpler to increase the default `maxx` in `get_size()` to 85? Otherwise it's impossible to display the counters in single-run mode.

Is it really necessary to do all these checks for the terminal size when `--single-run` is set. If the table lines are wrapping, we can resize terminal window?