### PR TITLE
Add option to invert the filters

### DIFF
--- a/WISHLIST
+++ b/WISHLIST
@@ -5,7 +5,6 @@ This is an overview of the common ones and where they are on the priority list.
 
 Features coming soon:
 - Filtering hostnames
-- Inverse filtering
 - Display NAT'd IP
 
 Features that may come later:

--- a/iptstate.8
+++ b/iptstate.8
@@ -38,6 +38,9 @@ Only show states with a destination port of \fIport\fP
 .B -h, --help
 Show help message
 .TP
+.B -i, --invert-filters
+Invert filters to display non-matching results
+.TP
 .B -l, --lookup
 Show hostnames instead of IP addresses. Enabling this will also enable \fB-L\fP to prevent an ever-growing number of DNS requests.
 .TP

--- a/iptstate.cc
+++ b/iptstate.cc
@@ -1093,43 +1093,33 @@ int conntrack_hook(enum nf_conntrack_msg_type nf_type, struct nf_conntrack *ct,
     return NFCT_CB_CONTINUE;
   }
 
-  if (flags->filter_inv) {
-    if (flags->filter_src && ! (memcmp(&(entry->src), &(filters->src), entrysize))) {
+  if (flags->filter_src) {
+    if ((flags->filter_inv && !memcmp(&(entry->src), &(filters->src), entrysize)) || 
+    (!flags->filter_inv && memcmp(&(entry->src), &(filters->src), entrysize))) {
       counts->skipped++;
       return NFCT_CB_CONTINUE;
     }
+  }
 
-    if (flags->filter_srcpt && (entry->srcpt == filters->srcpt)) {
+  if (flags->filter_srcpt) {
+    if ((flags->filter_inv && entry->srcpt == filters->srcpt) || 
+    (!flags->filter_inv && entry->srcpt != filters->srcpt)) {
       counts->skipped++;
       return NFCT_CB_CONTINUE;
     }
+  }
 
-    if (flags->filter_dst && ! (memcmp(&(entry->dst), &(filters->dst), entrysize))) {
+  if (flags->filter_dst) {
+    if ((flags->filter_inv && !memcmp(&(entry->dst), &(filters->dst), entrysize)) || 
+    (!flags->filter_inv && memcmp(&(entry->dst), &(filters->dst), entrysize))) {
       counts->skipped++;
       return NFCT_CB_CONTINUE;
     }
+  }
 
-    if (flags->filter_dstpt && (entry->dstpt == filters->dstpt)) {
-      counts->skipped++;
-      return NFCT_CB_CONTINUE;
-    }
-  } else {
-    if (flags->filter_src && (memcmp(&(entry->src), &(filters->src), entrysize))) {
-      counts->skipped++;
-      return NFCT_CB_CONTINUE;
-    }
-
-    if (flags->filter_srcpt && (entry->srcpt != filters->srcpt)) {
-      counts->skipped++;
-      return NFCT_CB_CONTINUE;
-    }
-
-    if (flags->filter_dst && (memcmp(&(entry->dst), &(filters->dst), entrysize))) {
-      counts->skipped++;
-      return NFCT_CB_CONTINUE;
-    }
-
-    if (flags->filter_dstpt && (entry->dstpt != filters->dstpt)) {
+  if (flags->filter_dstpt) {
+    if ((flags->filter_inv && entry->dstpt == filters->dstpt) || 
+    (!flags->filter_inv && entry->dstpt != filters->dstpt)) {
       counts->skipped++;
       return NFCT_CB_CONTINUE;
     }

--- a/iptstate.cc
+++ b/iptstate.cc
@@ -1853,16 +1853,14 @@ void interactive_help(const string &sorting, const flags_t &flags,
 
   char tmp[NAMELEN];
   if (flags.filter_src) {
-    inet_ntop(filters.srcfam, &filters.src, tmp,
-              filters.srcfam == AF_INET ? sizeof(in_addr) : sizeof(in6_addr));
+    inet_ntop(filters.srcfam, &filters.src, tmp, NAMELEN-1);
     mvwaddstr(helpwin, y++, x, "  Source filter: ");
     wattron(helpwin, A_BOLD);
     waddstr(helpwin, tmp);
     wattroff(helpwin, A_BOLD);
   }
   if (flags.filter_dst) {
-    inet_ntop(filters.dstfam, &filters.dst, tmp,
-              filters.dstfam == AF_INET ? sizeof(in_addr) : sizeof(in6_addr));
+    inet_ntop(filters.dstfam, &filters.dst, tmp, NAMELEN-1);
     mvwaddstr(helpwin, y++, x, "  Destination filter: ");
     wattron(helpwin, A_BOLD);
     waddstr(helpwin, tmp);

--- a/iptstate.cc
+++ b/iptstate.cc
@@ -1095,7 +1095,7 @@ int conntrack_hook(enum nf_conntrack_msg_type nf_type, struct nf_conntrack *ct,
 
   if (flags->filter_src) {
     if ((flags->filter_inv && !memcmp(&(entry->src), &(filters->src), entrysize)) || 
-    (!flags->filter_inv && memcmp(&(entry->src), &(filters->src), entrysize))) {
+        (!flags->filter_inv && memcmp(&(entry->src), &(filters->src), entrysize))) {
       counts->skipped++;
       return NFCT_CB_CONTINUE;
     }
@@ -1103,7 +1103,7 @@ int conntrack_hook(enum nf_conntrack_msg_type nf_type, struct nf_conntrack *ct,
 
   if (flags->filter_srcpt) {
     if ((flags->filter_inv && entry->srcpt == filters->srcpt) || 
-    (!flags->filter_inv && entry->srcpt != filters->srcpt)) {
+        (!flags->filter_inv && entry->srcpt != filters->srcpt)) {
       counts->skipped++;
       return NFCT_CB_CONTINUE;
     }
@@ -1111,7 +1111,7 @@ int conntrack_hook(enum nf_conntrack_msg_type nf_type, struct nf_conntrack *ct,
 
   if (flags->filter_dst) {
     if ((flags->filter_inv && !memcmp(&(entry->dst), &(filters->dst), entrysize)) || 
-    (!flags->filter_inv && memcmp(&(entry->dst), &(filters->dst), entrysize))) {
+        (!flags->filter_inv && memcmp(&(entry->dst), &(filters->dst), entrysize))) {
       counts->skipped++;
       return NFCT_CB_CONTINUE;
     }
@@ -1119,7 +1119,7 @@ int conntrack_hook(enum nf_conntrack_msg_type nf_type, struct nf_conntrack *ct,
 
   if (flags->filter_dstpt) {
     if ((flags->filter_inv && entry->dstpt == filters->dstpt) || 
-    (!flags->filter_inv && entry->dstpt != filters->dstpt)) {
+        (!flags->filter_inv && entry->dstpt != filters->dstpt)) {
       counts->skipped++;
       return NFCT_CB_CONTINUE;
     }


### PR DESCRIPTION
Add option `-i, --invert-filters` to invert all filters globally. 

There is also a fix for the filtered IP not being displayed in interactive help. Using the buffer size `NAMELEN` that is used in all other `inet_ntop` functions seems to fix the problem.