### PR TITLE
Add network filtering

### DIFF
--- a/iptstate.8
+++ b/iptstate.8
@@ -28,8 +28,9 @@ Toggle color-code by protocol
 .B -C, --counters
 Toggle display of bytes/packets counters
 .TP
-.B -d, --dst-filter \fIIP\fP
-Only show states with a destination of \fIIP\fP
+.B -d, --dst-filter \fIIP/NETMASK\fP
+Only show states with a destination of \fIIP\fP and with optional \fINETMASK\fP.
+.br
 Note, that this must be an IP, hostname matching is not yet supported.
 .TP
 .B -D --dstpt-filter \fIport\fP
@@ -97,8 +98,10 @@ Packets
 .br
 To sort by Source IP (or Name), don't use \-b. Sorting by bytes/packets is only available for kernels that support it, and only when compiled against libnetfilter_conntrack (the default).
 .TP
-.B -s, --src-filter \fIIP\fP
-Only show states with a source of \fIIP\fP. Note, that this must be an IP, hostname matching is not yet supported.
+.B -s, --src-filter \fIIP/NETMASK\fP
+Only show states with a source of \fIIP\fP and with optional \fINETMASK\fP.
+.br
+Note, that this must be an IP, hostname matching is not yet supported.
 .TP
 .B -S, --srcpt-filter \fIport\fP
 Only show states with a source port of \fIport\fP
@@ -166,7 +169,7 @@ Error communicating with the netfilter subsystem.
 Terminal too narrow
 
 .SH BUGS
-We don't support filtering on resolved names, and we don't support filtering on networks. IPv6 support is new and the dynamic formatting doesn't yet always handle IPv6 addresses as well as it should.
+We don't support filtering on resolved names. IPv6 support is new and the dynamic formatting doesn't yet always handle IPv6 addresses as well as it should.
 
 .SH BUG REPORTS
 All bugs should be reported to Phil Dibowitz <phil AT ipom DOT com>. Please see the \fBREADME\fR and \fBBUGS\fR for more information on bug reports. Please read the \fBWISHLIST\fR before sending in features you hope to see.  

--- a/iptstate.8
+++ b/iptstate.8
@@ -28,7 +28,7 @@ Toggle color-code by protocol
 .B -C, --counters
 Toggle display of bytes/packets counters
 .TP
-.B -d, --dst-filter \fIIP/NETMASK\fP
+.B -d, --dst-filter \fIIP[/NETMASK]\fP
 Only show states with a destination of \fIIP\fP and with optional \fINETMASK\fP.
 .br
 Note, that this must be an IP, hostname matching is not yet supported.
@@ -98,7 +98,7 @@ Packets
 .br
 To sort by Source IP (or Name), don't use \-b. Sorting by bytes/packets is only available for kernels that support it, and only when compiled against libnetfilter_conntrack (the default).
 .TP
-.B -s, --src-filter \fIIP/NETMASK\fP
+.B -s, --src-filter \fIIP[/NETMASK]\fP
 Only show states with a source of \fIIP\fP and with optional \fINETMASK\fP.
 .br
 Note, that this must be an IP, hostname matching is not yet supported.

--- a/iptstate.cc
+++ b/iptstate.cc
@@ -237,15 +237,19 @@ bool check_ip(const char *arg, in6_addr *addr, uint8_t *family, uint8_t *netmask
   // Check for netmask prefix
   p_arg = strrchr(arg, '/');
   if (p_arg == NULL) {
-    memcpy(ip, arg, NAMELEN);
+    memcpy(ip, arg, (strlen(arg) + 1));
     *has_netmask = false;
   } else {
     size_t ip_len = strlen(arg) - strlen(p_arg);
     memcpy(ip, arg, ip_len);
     ip[ip_len] = '\0';
 
-    int tmp = atoi(arg + ip_len + 1);
-    if (tmp > 128) return false;  // Max IPv6 prefix length
+    const char *arg_net = arg + ip_len + 1;
+    if(arg_net[0] == '\0')
+      return false;
+    int tmp = atoi(arg_net);
+    if (tmp < 0 || tmp > 128)
+      return false; // Max IPv6 prefix length
     *has_netmask = true;
     *netmask = (uint8_t) tmp;
   }
@@ -259,7 +263,8 @@ bool check_ip(const char *arg, in6_addr *addr, uint8_t *family, uint8_t *netmask
   }
   ret = inet_pton(AF_INET, ip, addr);
   if (ret) {
-    if (has_netmask && *netmask > 32) return false; // Max IPv4 prefix length
+    if (*has_netmask && *netmask > 32)
+      return false; // Max IPv4 prefix length
     *family = AF_INET;
     return true;
   }

--- a/iptstate.cc
+++ b/iptstate.cc
@@ -244,10 +244,10 @@ bool check_ip(const char *arg, in6_addr *addr, uint8_t *family, uint8_t *netmask
     memcpy(ip, arg, ip_len);
     ip[ip_len] = '\0';
 
-    const char *arg_net = arg + ip_len + 1;
-    if(arg_net[0] == '\0')
+    const char *net_int = arg + ip_len + 1;
+    if (net_int[0] == '\0')
       return false;
-    int tmp = atoi(arg_net);
+    int tmp = atoi(net_int);
     if (tmp < 0 || tmp > 128)
       return false; // Max IPv6 prefix length
     *has_netmask = true;
@@ -276,7 +276,6 @@ bool check_ip(const char *arg, in6_addr *addr, uint8_t *family, uint8_t *netmask
  * https://gist.github.com/duedal/b83303b4988a4afb2a75
  */
 bool match_netmask(uint8_t family, const in6_addr &address, const in6_addr &network, uint8_t bits) {
-
   if (family == AF_INET) {
     if (bits == 0) {
       // C99 6.5.7 (3): u32 << 32 is undefined behaviour

--- a/iptstate.cc
+++ b/iptstate.cc
@@ -244,14 +244,14 @@ bool check_ip(const char *arg, in6_addr *addr, uint8_t *family, uint8_t *netmask
     memcpy(ip, arg, ip_len);
     ip[ip_len] = '\0';
 
-    const char *net_int = arg + ip_len + 1;
-    if (net_int[0] == '\0')
+    const char *net_arg = arg + ip_len + 1;
+    if (net_arg[0] == '\0')
       return false;
-    int tmp = atoi(net_int);
-    if (tmp < 0 || tmp > 128)
+    int net_int = atoi(net_arg);
+    if (net_int < 0 || net_int > 128)
       return false; // Max IPv6 prefix length
     *has_netmask = true;
-    *netmask = (uint8_t) tmp;
+    *netmask = (uint8_t) net_int;
   }
 
   // Get IP


### PR DESCRIPTION
Add filtering on networks by allowing optional netmask for src & dst filters, for ex. `224.0.0.1/24`.

Ther current filters using `memcmp()` to match on a single IP address are kept in but this could be replaced by the new `match_netmask()` function with prefix `/32` for IPv4 and `/128`for IPv6. I didn't do any speed tests in this regard, but it could simplify the code.

Depends on #12 