### PR TITLE
Build system: respect LDFLAGS, use pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ SBIN?=$(PREFIX)/sbin
 INSTALL?=/usr/bin/install
 STRIP?=/usr/bin/strip
 MAN?=$(PREFIX)/share/man
+PKG_CONFIG?=pkg-config
 
 ### ADVANCED USERS AND PACKAGERS MIGHT WANT TO CHANGE THIS
 
@@ -25,7 +26,7 @@ CXXFLAGS?= -g -Wall -O2 -Werror=format-security -Wformat-truncation=0
 CXXFILES?= iptstate.cc
 
 # THIS IS FOR NORMAL COMPILATION
-LIBS?= -lncurses -lnetfilter_conntrack
+LIBS?= $(shell $(PKG_CONFIG) --libs ncurses libnetfilter_conntrack)
 CPPFLAGS=
 
 ### YOU SHOULDN'T NEED TO CHANGE ANYTHING BELOW THIS

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ CXXFILES?= iptstate.cc
 
 # THIS IS FOR NORMAL COMPILATION
 LIBS?= $(shell $(PKG_CONFIG) --libs ncurses libnetfilter_conntrack)
-CPPFLAGS=
 
 ### YOU SHOULDN'T NEED TO CHANGE ANYTHING BELOW THIS
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ iptstate: iptstate.cc Makefile
 	echo "+------------------------------------------------------------+" ;\
 	echo "";
 
-	$(CXX) $(CXXFLAGS) $(CXXFILES) -o iptstate $(LIBS) $(CPPFLAGS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(CXXFILES) -o iptstate $(LIBS)
 	@touch iptstate
 
 	@\

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Make sure you have some version of curses installed (for most users this is
 probably ncurses). Note that if you are using vendor packages you will most
 likely need the packaged with '-dev' on the end of of it (i.e. ncurses-dev).
 
-Starting with version 2.2.0 you also need libnetfilter_conntrack version 0.0.50
-or later. These libraries also require nf_conntrack_netlink and nfnetlink
-support in your kernel.
+Starting with version 2.2.0, you also need libnetfilter_conntrack version 0.0.50
+or later. These libraries also require nf_conntrack_netlink and nfnetlink support
+in your kernel. You will also need pkg-config at build-time.
 
 ## INSTALLATION
 


### PR DESCRIPTION
Hi!

These are two fixes I've applied downstream in Gentoo:
- respect the user's LDFLAGS
- use pkg-config to find the correct libraries to link against